### PR TITLE
Test that we are inline with the BSON Object ID spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,14 @@ jobs:
           rustup-toolchain: stable
           bundler-cache: true
           cargo-cache: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.104
       - name: Install dependencies
         run: bundle install
       - name: Lint Rust code
         run: cargo clippy -- -D warnings
       - name: Test Rust code
-        run: cargo test
+        run: cargo nextest run
       - name: Build and test Ruby gem
         run: bundle exec rake build test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- Ruby entrypoints live in `lib/`; `lib/penguin.rb` wires the extension and
+  exposes `Penguin::ObjectId`.
+- The Rust crate is in `crates/object_id`, this is usable on its own without any
+  Ruby dependency.
+- The native extension is generated from `ext/penguin_object_id` which is a
+  light wrapper around `crates/object_id`. No logic should live here. It is
+  compiled into into `lib/penguin_object_id.bundle` via rb-sys.
+- Ruby level tests and benchmarks sit in `test/`, following `test_*.rb` and
+  `bench_*.rb` patterns.
+- The BSON Object ID spec can be found in `specifications/object_id.md`
+
+## Build, Test, and Development Commands
+
+- `bundle exec rake test`: compile the extension (if needed) and execute the
+  full Minitest suite, including benchmarks.
+- `cargo test -p object_id`: run Rust unit tests in isolation
+- `cargo bench -p object_id`: execute Criterion benchmarks for the Rust core
+  implementation.
+
+## Testing Guidelines
+
+- Aim to keep parity with BSON’s expectations; consult
+  `specifications/object_id.md` when drafting scenarios.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 - `bundle exec rake test`: compile the extension (if needed) and execute the
   full Minitest suite, including benchmarks.
-- `cargo test -p object_id`: run Rust unit tests in isolation
+- `cargo nextest run -p object_id`: run Rust unit tests in isolation
 - `cargo bench -p object_id`: execute Criterion benchmarks for the Rust core
   implementation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude
+
+Please read AGENTS.md.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To install this gem onto your local machine:
 1. Run `bundle install`
 2. Compile and test using `bundle exec rake build test`
 
-You can run and test the Rust code by itself using cargo.
+You can run and test the Rust code by itself using cargo and cargo-nextest.
 
 ### Benchmarking
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,13 @@ Minitest::TestTask.create do |t|
   t.test_globs = ["test/test_*.rb", "test/bench_*.rb"]
 end
 
+
 require "rb_sys/extensiontask"
 
 task build: :compile
+
+# Ensure the extension has been compiled before running tests.
+task test: :compile
 
 GEMSPEC = Gem::Specification.load("penguin.gemspec")
 

--- a/crates/object_id/Cargo.toml
+++ b/crates/object_id/Cargo.toml
@@ -14,6 +14,9 @@ thiserror = "2.0.16"
 pprof = { version = "0.15.0", features = ["flamegraph", "criterion"] }
 criterion = "0.5.0"
 
+[lib]
+bench = false
+
 [[bench]]
 name = "object_id_generation"
 harness = false

--- a/crates/object_id/src/lib.rs
+++ b/crates/object_id/src/lib.rs
@@ -49,7 +49,9 @@ impl ObjectId {
     /// Generate an, optionally unique, object ID for the given time.
     pub fn from_time(t: i64, unique: bool) -> Self {
         let counter = if unique {
-            let counter = COUNTER.fetch_add(1, Ordering::SeqCst);
+            // We don't care that there is an ordering between threads, just
+            // that each ID gets a unique value.
+            let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
             let bs = counter.to_be_bytes();
             [bs[1], bs[2], bs[3]]
         } else {

--- a/crates/object_id/src/lib.rs
+++ b/crates/object_id/src/lib.rs
@@ -196,6 +196,15 @@ mod tests {
     }
 
     #[test]
+    fn test_counter_handles_u32_overflow() {
+        COUNTER.store(u32::MAX, Ordering::Relaxed);
+        let first = ObjectId::from_time(0, true);
+        let second = ObjectId::from_time(0, true);
+        assert_eq!(first.counter(), COUNTER_MAX);
+        assert_eq!(second.counter(), 0);
+    }
+
+    #[test]
     fn test_timestamp_values() {
         // 0x00000000: Jan 1st, 1970 00:00:00 UTC
         let id = ObjectId::from_time(0, false);

--- a/crates/object_id/src/lib.rs
+++ b/crates/object_id/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicU32, Ordering},
     LazyLock,
+    atomic::{AtomicU32, Ordering},
 };
 
 /// Global counter for differentiating IDs within the same second. Per the spec,
@@ -125,7 +125,10 @@ impl PartialOrd for ObjectId {
 
 impl Ord for ObjectId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.to_bytes().cmp(&other.to_bytes())
+        self.timestamp
+            .cmp(&other.timestamp)
+            .then_with(|| self.machine_id.cmp(&other.machine_id))
+            .then_with(|| self.counter.cmp(&other.counter))
     }
 }
 
@@ -142,7 +145,7 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use crate::{ObjectId, COUNTER, COUNTER_MAX};
+    use crate::{COUNTER, COUNTER_MAX, ObjectId};
 
     #[test]
     fn from_time_truncates_timestamp() {

--- a/crates/object_id/src/lib.rs
+++ b/crates/object_id/src/lib.rs
@@ -170,6 +170,12 @@ mod tests {
         assert_eq!(id.cmp(&id), std::cmp::Ordering::Equal);
     }
 
+    // Note: This test is the reason for the usage of nextest. It requires full
+    // control over the global counter state so running tests in parallel in the
+    // same process is not possible. We could use something like serial_test but
+    // that's quite brittle in that it requires all tests to be properly
+    // annotated. Instead, using nextest creates a binary for each test, so
+    // they're run in their own process and can't effect one another.
     #[test]
     fn test_counter_overflow() {
         COUNTER.store(COUNTER_MAX, Ordering::Relaxed);

--- a/crates/object_id/src/lib.rs
+++ b/crates/object_id/src/lib.rs
@@ -188,4 +188,44 @@ mod tests {
         assert_eq!(third.counter(), 1, "third ID should have counter 1");
         assert_eq!(fourth.counter(), 2, "fourth ID should have counter 2");
     }
+
+    #[test]
+    fn test_timestamp_values() {
+        // 0x00000000: Jan 1st, 1970 00:00:00 UTC
+        let id = ObjectId::from_time(0, false);
+        assert_eq!(id.timestamp(), 0);
+
+        // 0x7FFFFFFF: Jan 19th, 2038 03:14:07 UTC
+        let id = ObjectId::from_time(0x7FFFFFFF, false);
+        assert_eq!(id.timestamp(), 0x7FFFFFFF);
+
+        // 0x80000000: Jan 19th, 2038 03:14:08 UTC
+        let id = ObjectId::from_time(0x80000000u32 as i64, false);
+        assert_eq!(id.timestamp(), 0x80000000u32 as i64);
+
+        // 0xFFFFFFFF: Feb 7th, 2106 06:28:15 UTC
+        let id = ObjectId::from_time(0xFFFFFFFFu32 as i64, false);
+        assert_eq!(id.timestamp(), 0xFFFFFFFFu32 as i64);
+    }
+
+    #[test]
+    fn test_hex_string_parsing() {
+        let hex = "507f1f77bcf86cd799439011";
+        let id = ObjectId::try_from(hex.to_string()).unwrap();
+        assert_eq!(hex::encode(id.to_bytes()), hex);
+    }
+
+    #[test]
+    fn test_ordering_by_timestamp_then_counter() {
+        let id1 = ObjectId::from_time(100, true); // earlier timestamp
+        let id2 = ObjectId::from_time(200, true); // later timestamp
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_big_endian_format() {
+        let id = ObjectId::from_time(0x12345678, false);
+        let bytes = id.to_bytes();
+        assert_eq!(&bytes[0..4], &[0x12, 0x34, 0x56, 0x78]); // timestamp big endian
+    }
 }

--- a/crates/object_id/src/lib.rs
+++ b/crates/object_id/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Error {
     InvalidHexIdLength(usize),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ObjectId {
     timestamp: [u8; 4],
     machine_id: [u8; 5],
@@ -116,14 +116,6 @@ impl TryFrom<String> for ObjectId {
         })
     }
 }
-
-impl PartialEq for ObjectId {
-    fn eq(&self, other: &Self) -> bool {
-        self.to_bytes() == other.to_bytes()
-    }
-}
-
-impl Eq for ObjectId {}
 
 impl PartialOrd for ObjectId {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {

--- a/specifications/objectid.md
+++ b/specifications/objectid.md
@@ -1,0 +1,136 @@
+# BSON ObjectID
+
+- Status: Accepted
+- Minimum Server Version: N/A
+
+______________________________________________________________________
+
+## Abstract
+
+This specification documents the format and data contents of ObjectID BSON values that the drivers and the server
+generate when no field values have been specified (e.g. creating an ObjectID BSON value when no `_id` field is present
+in a document). It is primarily aimed to provide an alternative to the historical use of the MD5 hashing algorithm for
+the machine information field of the ObjectID, which is problematic when providing a FIPS compliant implementation. It
+also documents existing best practices for the timestamp and counter fields.
+
+## META
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and
+"OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+## Specification
+
+The [ObjectID](https://www.mongodb.com/docs/manual/reference/method/ObjectId/) BSON type is a 12-byte value consisting
+of three different portions (fields):
+
+- a 4-byte value representing the seconds since the Unix epoch in the highest order bytes,
+- a 5-byte random number unique to a machine and process,
+- a 3-byte counter, starting with a random value.
+
+```text
+4 byte timestamp    5 byte process unique   3 byte counter
+|<----------------->|<---------------------->|<------------>|
+[----|----|----|----|----|----|----|----|----|----|----|----]
+0                   4                   8                   12
+```
+
+### Timestamp Field
+
+This 4-byte big endian field represents the seconds since the Unix epoch (Jan 1st, 1970, midnight UTC). It is an ever
+increasing value that will have a range until about Jan 7th, 2106.
+
+Drivers MUST create ObjectIDs with this value representing the number of seconds since the Unix epoch.
+
+Drivers MUST interpret this value as an **unsigned 32-bit integer** when conversions to language specific date/time
+values are created, and when converting this to a timestamp.
+
+Drivers SHOULD have an accessor method on an ObjectID class for obtaining the timestamp value.
+
+### Random Value
+
+A 5-byte field consisting of a random value generated once per process. This random value is unique to the machine and
+process.
+
+Drivers MUST NOT have an accessor method on an ObjectID class for obtaining this value.
+
+The random number does not have to be cryptographic. If possible, use a PRNG with OS supplied entropy that SHOULD NOT
+block to wait for more entropy to become available. Otherwise, seed a deterministic PRNG to ensure uniqueness of process
+and machine by combining time, process ID, and hostname.
+
+### Counter
+
+A 3-byte big endian counter.
+
+This counter MUST be initialised to a random value when the driver is first activated. After initialisation, the counter
+MUST be increased by 1 for every ObjectID creation.
+
+When the counter overflows (i.e., hits 16777215+1), the counter MUST be reset to 0.
+
+Drivers MUST NOT have an accessor method on an ObjectID class for obtaining this value.
+
+The random number does not have to be cryptographic. If possible, use a PRNG with OS supplied entropy that SHOULD NOT
+block to wait for more entropy to become available. Otherwise, seed a deterministic PRNG to ensure uniqueness of process
+and machine by combining time, process ID, and hostname.
+
+## Test Plan
+
+Drivers MUST:
+
+- Ensure that the Timestamp field is represented as an unsigned 32-bit representing the number of seconds since the
+    Epoch for the Timestamp values:
+    - `0x00000000`: To match `"Jan 1st, 1970 00:00:00 UTC"`
+    - `0x7FFFFFFF`: To match `"Jan 19th, 2038 03:14:07 UTC"`
+    - `0x80000000`: To match `"Jan 19th, 2038 03:14:08 UTC"`
+    - `0xFFFFFFFF`: To match `"Feb 7th, 2106 06:28:15 UTC"`
+- Ensure that the Counter field successfully overflows its sequence from `0xFFFFFF` to `0x000000`.
+- Ensure that after a new process is created through a fork() or similar process creation operation, the "random number
+    unique to a machine and process" is no longer the same as the parent process that created the new process.
+
+## Motivation for Change
+
+Besides the specific exclusion of MD5 as an allowed hashing algorithm, the information in this specification is meant to
+align the ObjectID generation algorithm of both drivers and the server.
+
+## Design Rationale
+
+**Timestamp:** The timestamp is a 32-bit **unsigned** integer, as it allows us to extend the furthest date that the
+timestamp can represent from the year 2038 to 2106. There is no reason why MongoDB would generate a timestamp to mean a
+date before 1970, as MongoDB did not exist back then.
+
+**Random Value:** Originally, this field consisted of the Machine ID and Process ID fields. There were numerous
+divergences between drivers due to implementation choices, and the Machine ID field traditionally used the MD5 hashing
+algorithm which can't be used on FIPS compliant machines. In order to allow for a similar behaviour among all drivers
+**and** the MongoDB Server, these two fields have been collated together into a single 5-byte random value, unique to a
+machine and process.
+
+**Counter:** The counter makes it possible to have multiple ObjectIDs per second, per server, and per process. As the
+counter can overflow, there is a possibility of having duplicate ObjectIDs if you create more than 16 million ObjectIDs
+per second in the same process on a single machine.
+
+**Endianness:** The *Timestamp* and *Counter* are big endian because we can then use `memcmp` to order ObjectIDs, and we
+want to ensure an increasing order.
+
+## Backwards Compatibility
+
+This specification requires that the existing *Machine ID* and *Process ID* fields are merged into a single 5-byte
+value. This will change the behaviour of ObjectID generation, as well as the behaviour of drivers that currently have
+getters and setters for the original *Machine ID* and *Process ID* fields.
+
+## Reference Implementation
+
+Currently there is no full reference implementation yet.
+
+## Changelog
+
+- 2024-07-30: Migrated from reStructuredText to Markdown.
+
+- 2022-10-05: Remove spec front matter and reformat changelog.
+
+- 2019-01-14: Clarify that the random numbers don't need to be cryptographically secure. Add a test to test that the
+    unique value is different in forked processes.
+
+- 2018-10-11: Clarify that the *Timestamp* and *Counter* fields are big endian, and add the reason why.
+
+- 2018-07-02: Replaced Machine ID and Process ID fields with a single 5-byte unique value
+
+- 2018-05-22: Initial Release


### PR DESCRIPTION
I've added the spec and have done a pass on checking we're inline with it. I've (and claude)
also added tests to make sure we stay inline with it. There were a few places
where we weren't compliant with the spec, see individual commits for details.
